### PR TITLE
Eliminate nop cast

### DIFF
--- a/onnxoptimizer/pass_registry.h
+++ b/onnxoptimizer/pass_registry.h
@@ -10,6 +10,7 @@
 
 #include "onnxoptimizer/passes/eliminate_deadend.h"
 #include "onnxoptimizer/passes/eliminate_identity.h"
+#include "onnxoptimizer/passes/eliminate_nop_cast.h"
 #include "onnxoptimizer/passes/eliminate_nop_dropout.h"
 #include "onnxoptimizer/passes/eliminate_nop_monotone_argmax.h"
 #include "onnxoptimizer/passes/eliminate_nop_pad.h"
@@ -44,6 +45,7 @@ struct GlobalPassRegistry {
     // Register the optimization passes to the optimizer.
     registerPass<NopEmptyPass>();
     registerPass<EliminateDeadEnd>();
+    registerPass<EliminateNopCast>();
     registerPass<EliminateNopDropout>();
     registerPass<EliminateIdentity>();
     registerPass<EliminateNopMonotoneArgmax>();

--- a/onnxoptimizer/passes/eliminate_nop_cast.h
+++ b/onnxoptimizer/passes/eliminate_nop_cast.h
@@ -1,0 +1,35 @@
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+#pragma once
+
+#include "onnxoptimizer/pass.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+
+struct EliminateNopCast final : public PredicateBasedPass {
+  explicit EliminateNopCast()
+      : PredicateBasedPass(
+            PassType::Nop,
+            PassEfficiency::Complete,
+            PassOptimizationType::Compute) {}
+
+  std::string getPassName() const override {
+    return "eliminate_nop_cast";
+  }
+
+  bool patternMatchPredicate(Node* node) override {
+    return (node->kind() == kCast && node->hasAttribute(kto) && node->input()->elemType() == node->i(kto));
+  }
+
+  bool runTransform(Node* node, Graph&, NodeDestroyType& destroy_current)
+      override {
+    node->output()->replaceAllUsesWith(node->input());
+    destroy_current = NodeDestroyType::DestroyOne;
+    return true;
+  }
+};
+
+} // namespace optimization
+} // namespace ONNX_NAMESPACE

--- a/onnxoptimizer/passes/eliminate_nop_cast.h
+++ b/onnxoptimizer/passes/eliminate_nop_cast.h
@@ -20,7 +20,8 @@ struct EliminateNopCast final : public PredicateBasedPass {
   }
 
   bool patternMatchPredicate(Node* node) override {
-    return (node->kind() == kCast && node->hasAttribute(kto) && node->input()->elemType() == node->i(kto));
+    return (node->kind() == kCast && node->hasAttribute(kto) &&
+      node->input()->elemType() == node->i(kto));
   }
 
   bool runTransform(Node* node, Graph&, NodeDestroyType& destroy_current)

--- a/onnxoptimizer/passes/eliminate_nop_cast.h
+++ b/onnxoptimizer/passes/eliminate_nop_cast.h
@@ -26,6 +26,9 @@ struct EliminateNopCast final : public PredicateBasedPass {
 
   bool runTransform(Node* node, Graph&, NodeDestroyType& destroy_current)
       override {
+    if (node->output()->has_sizes()) {
+        node->input()->setSizes(node->output()->sizes());
+    }
     node->output()->replaceAllUsesWith(node->input());
     destroy_current = NodeDestroyType::DestroyOne;
     return true;

--- a/onnxoptimizer/passes/eliminate_nop_cast.h
+++ b/onnxoptimizer/passes/eliminate_nop_cast.h
@@ -24,10 +24,14 @@ struct EliminateNopCast final : public PredicateBasedPass {
       node->input()->elemType() == node->i(kto));
   }
 
-  bool runTransform(Node* node, Graph&, NodeDestroyType& destroy_current)
+  bool runTransform(Node* node, Graph& graph, NodeDestroyType& destroy_current)
       override {
     if (node->output()->has_sizes()) {
         node->input()->setSizes(node->output()->sizes());
+    }
+    if (std::find(graph.outputs().rbegin(), graph.outputs().rend(),
+                  node->output()) != graph.outputs().rend()) {
+      node->input()->setUniqueName(node->output()->uniqueName());
     }
     node->output()->replaceAllUsesWith(node->input());
     destroy_current = NodeDestroyType::DestroyOne;

--- a/onnxoptimizer/test/optimizer_test.py
+++ b/onnxoptimizer/test/optimizer_test.py
@@ -160,6 +160,18 @@ class TestOptimizer(unittest.TestCase):
             assert node.op_type != "Identity"
         assert len(optimized_model.graph.node) == 2
 
+    def test_nop_cast(self):
+        cast = helper.make_node("Cast", ["A"], ["B"], to=TensorProto.FLOAT)
+        graph = helper.make_graph(
+            [cast],
+            "test",
+            [helper.make_tensor_value_info("A", TensorProto.FLOAT, (2, 3))],
+            [helper.make_tensor_value_info("B", TensorProto.FLOAT, (2, 3))])
+
+        optimized_model = self._optimized(graph, ["eliminate_nop_cast"])
+
+        assert len(optimized_model.graph.node) == 0
+
     def test_nop_transpose_graph_output(self):  # type: () -> None
         add = helper.make_node("Add", ["X", "Y"], ["A"])
         trans = helper.make_node("Transpose", ["A"], ["B"], perm=[0, 1])


### PR DESCRIPTION
Simple optimization pass to eliminate no-op casts (where the element type of the input tensor is equal to the element type we are casting to).