### PR TITLE
add torchvision model test, expose get_fuse_and_elimination_passes()

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,8 @@ jobs:
       CIBW_TEST_REQUIRES_LINUX: pytest==5.4.3 nbval flake8 mypy
       CIBW_TEST_REQUIRES_MACOS: pytest==5.4.3 nbval
       CIBW_TEST_REQUIRES_WINDOWS: pytest==5.4.3 nbval onnxruntime
-      CIBW_BEFORE_TEST_WINDOWS: pip install torch==1.7.1+cpu torchvision==0.8.2+cpu torchaudio===0.7.2 -f https://download.pytorch.org/whl/torch_stable.html
+      # latest pytorch is not available on py3.5, just ignore the error
+      CIBW_BEFORE_TEST_WINDOWS: pip install torch==1.7.1+cpu torchvision==0.8.2+cpu torchaudio===0.7.2 -f https://download.pytorch.org/whl/torch_stable.html || true
       CIBW_TEST_COMMAND: pytest {project}/onnxoptimizer/test
       CIBW_TEST_COMMAND_LINUX: cd {project} && flake8 && ! grep -R --include='*.cc' --include='*.h' 'namespace onnx' . && ! grep -R --include='*.cc' --include='*.h' 'onnx::' . && python setup.py typecheck && pytest
       CIBW_ENVIRONMENT: CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=OFF -DProtobuf_USE_STATIC_LIBS=ON -DONNX_USE_LITE_PROTO=ON"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,8 @@ jobs:
       CIBW_BEFORE_ALL_WINDOWS: bash -c "WD=`pwd` && git clone https://github.com/protocolbuffers/protobuf.git  && cd protobuf && git checkout v3.13.0 && cd cmake && mkdir build && cd build && cmake -G \"Visual Studio 15 2017 Win64\" -Dprotobuf_MSVC_STATIC_RUNTIME=OFF -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_BUILD_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=C:/protobuf_install -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON .. && cmake --build . --config Release -j4 && cmake -P cmake_install.cmake --config Release && cd $WD && rm -rf protobuf"
       CIBW_TEST_REQUIRES_LINUX: pytest==5.4.3 nbval flake8 mypy
       CIBW_TEST_REQUIRES_MACOS: pytest==5.4.3 nbval
-      CIBW_TEST_REQUIRES_WINDOWS: pytest==5.4.3 nbval onnxruntime torch torchvision
+      CIBW_TEST_REQUIRES_WINDOWS: pytest==5.4.3 nbval onnxruntime
+      CIBW_BEFORE_TEST_WINDOWS: pip install torch==1.7.1+cpu torchvision==0.8.2+cpu torchaudio===0.7.2 -f https://download.pytorch.org/whl/torch_stable.html
       CIBW_TEST_COMMAND: pytest {project}/onnxoptimizer/test
       CIBW_TEST_COMMAND_LINUX: cd {project} && flake8 && ! grep -R --include='*.cc' --include='*.h' 'namespace onnx' . && ! grep -R --include='*.cc' --include='*.h' 'onnx::' . && python setup.py typecheck && pytest
       CIBW_ENVIRONMENT: CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=OFF -DProtobuf_USE_STATIC_LIBS=ON -DONNX_USE_LITE_PROTO=ON"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,7 @@ jobs:
       CIBW_BEFORE_ALL_WINDOWS: bash -c "WD=`pwd` && git clone https://github.com/protocolbuffers/protobuf.git  && cd protobuf && git checkout v3.13.0 && cd cmake && mkdir build && cd build && cmake -G \"Visual Studio 15 2017 Win64\" -Dprotobuf_MSVC_STATIC_RUNTIME=OFF -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_BUILD_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=C:/protobuf_install -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON .. && cmake --build . --config Release -j4 && cmake -P cmake_install.cmake --config Release && cd $WD && rm -rf protobuf"
       CIBW_TEST_REQUIRES_LINUX: pytest==5.4.3 nbval flake8 mypy
       CIBW_TEST_REQUIRES_MACOS: pytest==5.4.3 nbval
-      CIBW_TEST_REQUIRES_WINDOWS: pytest==5.4.3 nbval onnxruntime
+      CIBW_TEST_REQUIRES_WINDOWS: pytest==5.4.3 nbval onnxruntime torch torchvision
       CIBW_TEST_COMMAND: pytest {project}/onnxoptimizer/test
       CIBW_TEST_COMMAND_LINUX: cd {project} && flake8 && ! grep -R --include='*.cc' --include='*.h' 'namespace onnx' . && ! grep -R --include='*.cc' --include='*.h' 'onnx::' . && python setup.py typecheck && pytest
       CIBW_ENVIRONMENT: CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=OFF -DProtobuf_USE_STATIC_LIBS=ON -DONNX_USE_LITE_PROTO=ON"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,14 +5,15 @@ on: [push, pull_request]
 jobs:
   build_wheels:
     env:
+      CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
       CIBW_BEFORE_ALL_LINUX: WD=`pwd` && /opt/python/cp38-cp38/bin/python -m pip install cmake && cp /opt/python/cp38-cp38/bin/cmake /usr/bin/cmake && mkdir temp && curl -L https://github.com/protocolbuffers/protobuf/releases/download/v3.13.0/protobuf-all-3.13.0.tar.gz -o protobuf.tar.gz && tar xf protobuf.tar.gz -C temp && rm -rf protobuf.tar.gz && cd temp/* && mkdir cmake/build && cd cmake/build && cmake -Dprotobuf_BUILD_TESTS=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_BUILD_TYPE=Release .. && cmake --build . -j4 && cmake -P cmake_install.cmake && cd $WD && rm -rf temp
       CIBW_BEFORE_ALL_MACOS: WD=`pwd` && pip install cmake && git clone https://github.com/protocolbuffers/protobuf.git && cd protobuf && git checkout v3.13.0 && cd cmake && mkdir build && cd build && cmake -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_BUILD_EXAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_BUILD_TYPE=Release .. && cmake --build . -j4 && cmake -P cmake_install.cmake && cd $WD && rm -rf protobuf
       CIBW_BEFORE_ALL_WINDOWS: bash -c "WD=`pwd` && git clone https://github.com/protocolbuffers/protobuf.git  && cd protobuf && git checkout v3.13.0 && cd cmake && mkdir build && cd build && cmake -G \"Visual Studio 15 2017 Win64\" -Dprotobuf_MSVC_STATIC_RUNTIME=OFF -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_BUILD_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=C:/protobuf_install -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON .. && cmake --build . --config Release -j4 && cmake -P cmake_install.cmake --config Release && cd $WD && rm -rf protobuf"
-      CIBW_TEST_REQUIRES_LINUX: pytest==5.4.3 nbval flake8 mypy
+      CIBW_TEST_REQUIRES_LINUX: pytest==5.4.3 nbval flake8 mypy onnxruntime
       CIBW_TEST_REQUIRES_MACOS: pytest==5.4.3 nbval
-      CIBW_TEST_REQUIRES_WINDOWS: pytest==5.4.3 nbval onnxruntime
+      CIBW_TEST_REQUIRES_WINDOWS: pytest==5.4.3 nbval
       # latest pytorch is not available on py3.5, just ignore the error
-      CIBW_BEFORE_TEST_WINDOWS: pip install torch==1.7.1+cpu torchvision==0.8.2+cpu torchaudio===0.7.2 -f https://download.pytorch.org/whl/torch_stable.html || true
+      CIBW_BEFORE_TEST_LINUX: pip install torch==1.7.1+cpu torchvision==0.8.2+cpu torchaudio==0.7.2 -f https://download.pytorch.org/whl/torch_stable.html || true
       CIBW_TEST_COMMAND: pytest {project}/onnxoptimizer/test
       CIBW_TEST_COMMAND_LINUX: cd {project} && flake8 && ! grep -R --include='*.cc' --include='*.h' 'namespace onnx' . && ! grep -R --include='*.cc' --include='*.h' 'onnx::' . && python setup.py typecheck && pytest
       CIBW_ENVIRONMENT: CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=OFF -DProtobuf_USE_STATIC_LIBS=ON -DONNX_USE_LITE_PROTO=ON"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,13 @@ You can install onnxoptimizer from PyPI:
 pip3 install onnxoptimizer
 ```
 
-Or build it from source:
+Note that you may need to upgrade your pip first if you have trouble:
+
+```bash
+pip3 install -U pip
+```
+
+If you want to build from source:
 
 ```bash
 git clone --recursive https://github.com/onnx/optimizer onnxoptimizer

--- a/examples/onnx_optimizer_exec.cpp
+++ b/examples/onnx_optimizer_exec.cpp
@@ -16,19 +16,12 @@ int main(int argc, char **argv) {
     std::cout << "load failed" << std::endl;
     return -1;
   }
-  onnx::optimization::Optimize(
+  const auto new_model = onnx::optimization::Optimize(
       model,
-      {"eliminate_deadend", "eliminate_nop_dropout", "eliminate_nop_cast",
-       "eliminate_nop_monotone_argmax", "eliminate_nop_pad",
-       "extract_constant_to_initializer", "eliminate_unused_initializer",
-       "eliminate_nop_transpose", "eliminate_nop_flatten", "eliminate_identity",
-       "fuse_add_bias_into_conv", "fuse_consecutive_concats",
-       "fuse_consecutive_log_softmax", "fuse_consecutive_reduce_unsqueeze",
-       "fuse_consecutive_squeezes", "fuse_consecutive_transposes",
-       "fuse_matmul_add_bias_into_gemm", "fuse_pad_into_conv",
-       "fuse_transpose_into_gemm"});
+      onnx::optimization::GetFuseAndEliminationPass()
+      );
   std::ofstream ofs(argv[2]);
-  success = model.SerializePartialToOstream(&ofs);
+  success = new_model.SerializePartialToOstream(&ofs);
   if (!success) {
     std::cout << "save failed" << std::endl;
     return -1;

--- a/onnxoptimizer/__init__.py
+++ b/onnxoptimizer/__init__.py
@@ -17,36 +17,24 @@ import onnxoptimizer.onnx_opt_cpp2py_export as C
 from onnx import ModelProto
 from typing import Text, Sequence, Optional
 
-"""Apply the optimization on the serialized ModelProto.
-
-Arguments:
-    input (ModelProto): model
-    names (list of string): list of optimization names
-
-Return:
-    return (ModelProto) optimized model
-
-Supported pass names:
-    -- nop
-    -- eliminate_identity
-    -- eliminate_nop_transpose
-    -- eliminate_nop_pad
-    -- eliminate_unused_initializer
-    -- fuse_consecutive_squeezes
-    -- fuse_consecutive_transposes
-    -- fuse_add_bias_into_conv
-    -- fuse_transpose_into_gemm
-"""
-
 get_available_passes = C.get_available_passes
+
+get_fuse_and_elimination_passes = C.get_fuse_and_elimination_passes
 
 
 def optimize(model, passes=None, fixed_point=False):  # type: (ModelProto, Optional[Sequence[Text]], bool) -> ModelProto
+    """Apply the optimization on the serialized ModelProto.
+
+    Arguments:
+        input (ModelProto): model
+        names (list of string): list of optimization names
+
+    Return:
+        return (ModelProto) optimized model
+    """
+
     if passes is None:
-        passes = ['eliminate_nop_transpose',
-                  'eliminate_nop_pad',
-                  'fuse_consecutive_transposes',
-                  'fuse_transpose_into_gemm']
+        passes = get_fuse_and_elimination_passes()
     if not isinstance(model, ModelProto):
         raise ValueError(
             'Optimizer only accepts ModelProto, incorrect type: {}'.format(type(model)))
@@ -60,4 +48,4 @@ def optimize(model, passes=None, fixed_point=False):  # type: (ModelProto, Optio
     return onnx.load_from_string(optimized_model_str)
 
 
-__all__ = ['optimize', 'get_available_passes']
+__all__ = ['optimize', 'get_available_passes', 'get_fuse_and_elimination_passes']

--- a/onnxoptimizer/__init__.py
+++ b/onnxoptimizer/__init__.py
@@ -34,7 +34,11 @@ def optimize(model, passes=None, fixed_point=False):  # type: (ModelProto, Optio
     """
 
     if passes is None:
-        passes = get_fuse_and_elimination_passes()
+        print('WARNING: defualt optimization passes will be enlarged to all fuse and elimination passes in the next version')
+        passes = ['eliminate_nop_transpose',
+                  'eliminate_nop_pad',
+                  'fuse_consecutive_transposes',
+                  'fuse_transpose_into_gemm']
     if not isinstance(model, ModelProto):
         raise ValueError(
             'Optimizer only accepts ModelProto, incorrect type: {}'.format(type(model)))

--- a/onnxoptimizer/cpp2py_export.cc
+++ b/onnxoptimizer/cpp2py_export.cc
@@ -37,5 +37,6 @@ PYBIND11_MODULE(onnx_opt_cpp2py_export, onnx_opt_cpp2py_export) {
         return py::bytes(out);
       });
   onnx_opt_cpp2py_export.def("get_available_passes", &optimization::GetAvailablePasses);
+  onnx_opt_cpp2py_export.def("get_fuse_and_elimination_passes", &optimization::GetFuseAndEliminationPass);
 }
 }

--- a/onnxoptimizer/optimize.cc
+++ b/onnxoptimizer/optimize.cc
@@ -44,6 +44,9 @@ ModelProto OptimizeFixed(
 const std::vector<std::string> GetAvailablePasses() {
   return Optimizer::passes.GetAvailablePasses();
 }
+const std::vector<std::string> GetFuseAndEliminationPass() {
+  return Optimizer::passes.GetFuseAndEliminationPass();
+}
 
 } // namespace optimization
 } // namespace ONNX_NAMESPACE

--- a/onnxoptimizer/optimize.h
+++ b/onnxoptimizer/optimize.h
@@ -86,6 +86,8 @@ struct Optimizer {
 
 const std::vector<std::string> GetAvailablePasses();
 
+const std::vector<std::string> GetFuseAndEliminationPass();
+
 ModelProto Optimize(
     const ModelProto& mp_in,
     const std::vector<std::string>& names);

--- a/onnxoptimizer/pass_registry.cc
+++ b/onnxoptimizer/pass_registry.cc
@@ -18,5 +18,16 @@ const std::vector<std::string> GlobalPassRegistry::GetAvailablePasses() {
   return names;
 }
 
+const std::vector<std::string> GlobalPassRegistry::GetFuseAndEliminationPass() {
+  std::vector<std::string> names;
+  for (const auto& pass : this->passes) {
+    const auto pass_type = pass.second->getPassType();
+    if (pass_type == PassType::Fuse || pass_type == PassType::Nop) {
+      names.push_back(pass.first);
+    }
+  }
+  return names;
+}
+
 } // namespace optimization
 } // namespace ONNX_NAMESPACE

--- a/onnxoptimizer/pass_registry.h
+++ b/onnxoptimizer/pass_registry.h
@@ -88,6 +88,8 @@ struct GlobalPassRegistry {
   }
   const std::vector<std::string> GetAvailablePasses();
 
+  const std::vector<std::string> GetFuseAndEliminationPass();
+
   template <typename T>
   void registerPass() {
     static_assert(std::is_base_of<Pass, T>::value, "T must inherit from Pass");

--- a/onnxoptimizer/test/optimizer_test.py
+++ b/onnxoptimizer/test/optimizer_test.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from collections import OrderedDict
-from typing import Sequence, Text, Any, Tuple, List, Callable, Optional, Dict
+from typing import Sequence, Text, Any, Tuple, List, Callable, Optional, Dict, Union
 import tempfile
 import unittest
 import os

--- a/onnxoptimizer/test/optimizer_test.py
+++ b/onnxoptimizer/test/optimizer_test.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 
 from collections import OrderedDict
 from typing import Sequence, Text, Any, Tuple, List, Callable, Optional, Dict, Union
-import tempfile
+import io
 import unittest
 import os
 
@@ -2251,9 +2251,9 @@ class TestOptimizer(unittest.TestCase):
     def test_torchvision_fasterrcnn_fpn(self):    # type: () -> None
         model = tv.models.detection.fasterrcnn_resnet50_fpn(pretrained=False)
         x = [torch.rand(3, 300, 400), torch.rand(3, 500, 400)]
-        with tempfile.NamedTemporaryFile() as f:
+        with io.BytesIO() as f:
             torch.onnx.export(model, x, f, opset_version=11)
-            model = onnx.load(f.name)
+            model = onnx.load_model_from_string(f.getvalue())
             self._optimized(model, onnxoptimizer.get_fuse_and_elimination_passes(), fixed_point=True)
 
     # maskrcnn is only supported in opset 11 and higher
@@ -2261,9 +2261,9 @@ class TestOptimizer(unittest.TestCase):
     def test_torchvision_maskrcnn_fpn_opset11(self):    # type: () -> None
         model = tv.models.detection.maskrcnn_resnet50_fpn(pretrained=False)
         x = [torch.rand(3, 300, 400), torch.rand(3, 500, 400)]
-        with tempfile.NamedTemporaryFile() as f:
+        with io.BytesIO() as f:
             torch.onnx.export(model, x, f, opset_version=11)
-            model = onnx.load(f.name)
+            model = onnx.load_model_from_string(f.getvalue())
             self._optimized(model, onnxoptimizer.get_fuse_and_elimination_passes(), fixed_point=True)
 
     # keypointrcnn is only supported in opset 11 and higher
@@ -2271,36 +2271,36 @@ class TestOptimizer(unittest.TestCase):
     def test_torchvision_keypointrcnn_fpn(self):    # type: () -> None
         model = tv.models.detection.keypointrcnn_resnet50_fpn(pretrained=False)
         x = [torch.rand(3, 300, 400), torch.rand(3, 500, 400)]
-        with tempfile.NamedTemporaryFile() as f:
+        with io.BytesIO() as f:
             torch.onnx.export(model, x, f, opset_version=11)
-            model = onnx.load(f.name)
+            model = onnx.load_model_from_string(f.getvalue())
             self._optimized(model, onnxoptimizer.get_fuse_and_elimination_passes(), fixed_point=True)
 
     @unittest.skipUnless(has_tv, "This test needs torchvision")
     def test_torchvision_shufflenet_v2(self):    # type: () -> None
         model = tv.models.shufflenet_v2_x1_0(pretrained=False)
         x = torch.rand(1, 3, 224, 224)
-        with tempfile.NamedTemporaryFile() as f:
+        with io.BytesIO() as f:
             torch.onnx.export(model, x, f)
-            model = onnx.load(f.name)
+            model = onnx.load_model_from_string(f.getvalue())
             self._optimized(model, onnxoptimizer.get_fuse_and_elimination_passes(), fixed_point=True)
 
     @unittest.skipUnless(has_tv, "This test needs torchvision")
     def test_torchvision_mnasnet(self):    # type: () -> None
         model = tv.models.mnasnet1_0(pretrained=False)
         x = torch.rand(1, 3, 224, 224)
-        with tempfile.NamedTemporaryFile() as f:
+        with io.BytesIO() as f:
             torch.onnx.export(model, x, f)
-            model = onnx.load(f.name)
+            model = onnx.load_model_from_string(f.getvalue())
             self._optimized(model, onnxoptimizer.get_fuse_and_elimination_passes(), fixed_point=True)
 
     @unittest.skipUnless(has_tv, "This test needs torchvision")
     def test_torchvision_deeplabv3(self):    # type: () -> None
         model = tv.models.segmentation.deeplabv3_resnet50(pretrained=False)
         x = torch.rand(1, 3, 224, 224)
-        with tempfile.NamedTemporaryFile() as f:
+        with io.BytesIO() as f:
             torch.onnx.export(model, x, f)
-            model = onnx.load(f.name)
+            model = onnx.load_model_from_string(f.getvalue())
             self._optimized(model, onnxoptimizer.get_fuse_and_elimination_passes(), fixed_point=True)
 
 

--- a/onnxoptimizer/test/optimizer_test.py
+++ b/onnxoptimizer/test/optimizer_test.py
@@ -36,6 +36,8 @@ import onnxoptimizer
 TensorShape = List[int]
 TensorShapes = Dict[Optional[str], TensorShape]
 
+LATEST_STABLE_OPSET_VERSION = 13
+
 
 class TestOptimizer(unittest.TestCase):
     def _compare(self, model_opt: onnx.ModelProto, model_ori: onnx.ModelProto, n_times: int = 5,
@@ -158,7 +160,7 @@ class TestOptimizer(unittest.TestCase):
         else:
             opset_imports = kwargs.pop('opset_imports', None)
             if opset_imports is None:
-                opset_imports = [helper.make_opsetid("", 13)]
+                opset_imports = [helper.make_opsetid("", LATEST_STABLE_OPSET_VERSION)]
 
             orig_model = helper.make_model(
                 graph_or_model, producer_name='onnx-test', opset_imports=opset_imports, **kwargs)

--- a/onnxoptimizer/test/optimizer_test.py
+++ b/onnxoptimizer/test/optimizer_test.py
@@ -156,8 +156,12 @@ class TestOptimizer(unittest.TestCase):
         if isinstance(graph_or_model, ModelProto):
             orig_model = graph_or_model
         else:
+            opset_imports = kwargs.pop('opset_imports', None)
+            if opset_imports is None:
+                opset_imports = [helper.make_opsetid("", 13)]
+
             orig_model = helper.make_model(
-                graph_or_model, producer_name='onnx-test', **kwargs)
+                graph_or_model, producer_name='onnx-test', opset_imports=opset_imports, **kwargs)
         checker.check_model(orig_model)
         optimized_model = onnxoptimizer.optimize(orig_model, opts, fixed_point)
         checker.check_model(optimized_model)
@@ -2252,8 +2256,9 @@ class TestOptimizer(unittest.TestCase):
             model = onnx.load(f.name)
             self._optimized(model, onnxoptimizer.get_fuse_and_elimination_passes(), fixed_point=True)
 
+    # maskrcnn is only supported in opset 11 and higher
     @unittest.skipUnless(has_tv, "This test needs torchvision")
-    def test_torchvision_maskrcnn_fpn(self):    # type: () -> None
+    def test_torchvision_maskrcnn_fpn_opset11(self):    # type: () -> None
         model = tv.models.detection.maskrcnn_resnet50_fpn(pretrained=False)
         x = [torch.rand(3, 300, 400), torch.rand(3, 500, 400)]
         with tempfile.NamedTemporaryFile() as f:
@@ -2261,6 +2266,7 @@ class TestOptimizer(unittest.TestCase):
             model = onnx.load(f.name)
             self._optimized(model, onnxoptimizer.get_fuse_and_elimination_passes(), fixed_point=True)
 
+    # keypointrcnn is only supported in opset 11 and higher
     @unittest.skipUnless(has_tv, "This test needs torchvision")
     def test_torchvision_keypointrcnn_fpn(self):    # type: () -> None
         model = tv.models.detection.keypointrcnn_resnet50_fpn(pretrained=False)
@@ -2275,7 +2281,7 @@ class TestOptimizer(unittest.TestCase):
         model = tv.models.shufflenet_v2_x1_0(pretrained=False)
         x = torch.rand(1, 3, 224, 224)
         with tempfile.NamedTemporaryFile() as f:
-            torch.onnx.export(model, x, f, opset_version=11)
+            torch.onnx.export(model, x, f)
             model = onnx.load(f.name)
             self._optimized(model, onnxoptimizer.get_fuse_and_elimination_passes(), fixed_point=True)
 
@@ -2284,7 +2290,7 @@ class TestOptimizer(unittest.TestCase):
         model = tv.models.mnasnet1_0(pretrained=False)
         x = torch.rand(1, 3, 224, 224)
         with tempfile.NamedTemporaryFile() as f:
-            torch.onnx.export(model, x, f, opset_version=11)
+            torch.onnx.export(model, x, f)
             model = onnx.load(f.name)
             self._optimized(model, onnxoptimizer.get_fuse_and_elimination_passes(), fixed_point=True)
 
@@ -2293,7 +2299,7 @@ class TestOptimizer(unittest.TestCase):
         model = tv.models.segmentation.deeplabv3_resnet50(pretrained=False)
         x = torch.rand(1, 3, 224, 224)
         with tempfile.NamedTemporaryFile() as f:
-            torch.onnx.export(model, x, f, opset_version=11)
+            torch.onnx.export(model, x, f)
             model = onnx.load(f.name)
             self._optimized(model, onnxoptimizer.get_fuse_and_elimination_passes(), fixed_point=True)
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ MAKE = find_executable('make')
 
 install_requires = []
 setup_requires = []
-tests_require = []
 extras_require = {}
 
 ################################################################################
@@ -307,9 +306,6 @@ install_requires.extend([
 ################################################################################
 
 setup_requires.append('pytest-runner')
-tests_require.append('pytest')
-tests_require.append('nbval')
-tests_require.append('onnxruntime==1.6.0')
 
 if sys.version_info[0] == 3:
     # Mypy doesn't work with Python 2
@@ -330,7 +326,6 @@ setuptools.setup(
     include_package_data=True,
     install_requires=install_requires,
     setup_requires=setup_requires,
-    tests_require=tests_require,
     extras_require=extras_require,
     author='ONNX Optimizer Authors',
     author_email='onnx-technical-discuss@lists.lfai.foundation',


### PR DESCRIPTION
1. Expose a `get_fuse_and_elimination_passes()` API. It can be used to get all expected passes in most cases.
2. Test some models exported from torchvision, including maskrcnn with fpn, shufflenetv2, mnasnet, deeplabv3 and so on.
3. include some onnx patches https://github.com/onnx/onnx/pull/3218, https://github.com/onnx/onnx/pull/3220 and https://github.com/onnx/onnx/pull/3221
4.  (newly added) PyTorch is not so stable on Windows, so linux build docker has been switched from manylinux2010 to manylinux2014 to use PyTorch and onnxruntime on Linux
5.  (newly added) the default opset version of `onnx.helper.make_model` has been upgraded to 14, while onnxruntime only support up to 13, so I set the default opset version in test to 13
6.  (newly added) fix a bug in fuse_add_bias_into_conv optimizer 