### PR TITLE
rename input/output

### DIFF
--- a/onnxoptimizer/pass_registry.h
+++ b/onnxoptimizer/pass_registry.h
@@ -40,6 +40,7 @@
 #include "onnxoptimizer/passes/nop.h"
 #include "onnxoptimizer/passes/split.h"
 #include "onnxoptimizer/passes/eliminate_nop_expand.h"
+#include "onnxoptimizer/passes/rename_input_output.h"
 
 #include <unordered_set>
 #include <vector>
@@ -82,6 +83,7 @@ struct GlobalPassRegistry {
     registerPass<SplitInit>();
     registerPass<SplitPredict>();
     registerPass<EliminateNopExpand>();
+    registerPass<RenameInputOutput>();
   }
 
   ~GlobalPassRegistry() {

--- a/onnxoptimizer/passes/rename_input_output.h
+++ b/onnxoptimizer/passes/rename_input_output.h
@@ -70,7 +70,7 @@ struct RenameInputOutput final : public FullGraphBasedPass {
 
     for (int i = 0; i < graph.inputs().size(); ++i) {
       auto& value = graph.inputs()[i];
-      // ignore when input aslo in initializer
+      // ignore when input also in initializer
       if (initializer_names.count(value->uniqueName()) > 0) {
         continue;
       }

--- a/onnxoptimizer/passes/rename_input_output.h
+++ b/onnxoptimizer/passes/rename_input_output.h
@@ -74,7 +74,7 @@ struct RenameInputOutput final : public FullGraphBasedPass {
       if (initializer_names.count(value->uniqueName()) > 0) {
         continue;
       }
-      std::string current_name =
+      const std::string current_name =
           rename_patterns[0] + std::to_string(i) + rename_patterns[1];
 
       value->setUniqueName(current_name);

--- a/onnxoptimizer/passes/rename_input_output.h
+++ b/onnxoptimizer/passes/rename_input_output.h
@@ -38,15 +38,15 @@ struct RenameInputOutput final : public FullGraphBasedPass {
         [](const std::string& s, const std::string& pattern,
            const std::string& default_s) -> std::vector<std::string> {
       std::vector<std::string> res(2);
-      std::string tmp = s;
-      auto n = tmp.find(pattern);
+      const std::string* tmp = &s;
+      auto n = tmp->find(pattern);
       if (n == std::string::npos) {
-        tmp = default_s;
-        n = tmp.find(pattern);
+        tmp = &default_s;
+        n = tmp->find(pattern);
       }
 
-      res[0] = tmp.substr(0, n);
-      res[1] = tmp.substr(n + pattern.size());
+      res[0] = tmp->substr(0, n);
+      res[1] = tmp->substr(n + pattern.size());
       return res;
     };
     const std::string pattern{"%d"};
@@ -57,8 +57,7 @@ struct RenameInputOutput final : public FullGraphBasedPass {
     for (int i = 0; i < 2; ++i) {
       auto env_str = fetch_env(envs[i]);
       auto split_str = split_pattern(env_str, pattern, default_str[i]);
-      std::copy(split_str.begin(), split_str.end(),
-                std::back_insert_iterator<std::vector<std::string>>(result));
+      std::copy(split_str.begin(), split_str.end(), std::back_inserter(result));
     }
     return result;
   }
@@ -71,7 +70,7 @@ struct RenameInputOutput final : public FullGraphBasedPass {
 
     for (int i = 0; i < graph.inputs().size(); ++i) {
       auto& value = graph.inputs()[i];
-      // ingore when input aslo in initializer
+      // ignore when input aslo in initializer
       if (initializer_names.count(value->uniqueName()) > 0) {
         continue;
       }
@@ -83,7 +82,7 @@ struct RenameInputOutput final : public FullGraphBasedPass {
 
     for (int i = 0; i < graph.outputs().size(); ++i) {
       auto& value = graph.outputs()[i];
-      std::string current_name =
+      const std::string current_name =
           rename_patterns[2] + std::to_string(i) + rename_patterns[3];
       value->setUniqueName(current_name);
     }

--- a/onnxoptimizer/passes/rename_input_output.h
+++ b/onnxoptimizer/passes/rename_input_output.h
@@ -1,0 +1,99 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+#pragma once
+
+// fetch input/output pattern from environment variable
+// OPTIMIZER_RENAME_INPUT_PATTERN(default: input_%d) and
+// OPTIMIZER_RENAME_OUTPUT_PATTERN(default: output_%d).
+
+#include "onnxoptimizer/pass.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+
+struct RenameInputOutput final : public FullGraphBasedPass {
+  explicit RenameInputOutput()
+      : FullGraphBasedPass(PassType::Other, PassEfficiency::Complete,
+                           PassOptimizationType::None) {}
+
+  std::string getPassName() const override {
+    return "rename_input_output";
+  }
+
+  PassAnalysisType getPassAnalysisType() const override {
+    return PassAnalysisType::Empty;
+  }
+
+  std::vector<std::string> fetchPatternFromEnv() {
+    auto fetch_env = [](const std::string& env) -> std::string {
+      const auto* res = std::getenv(env.c_str());
+      return res ? std::string(res) : std::string{};
+    };
+    auto split_pattern =
+        [](const std::string& s, const std::string& pattern,
+           const std::string& default_s) -> std::vector<std::string> {
+      std::vector<std::string> res(2);
+      std::string tmp = s;
+      auto n = tmp.find(pattern);
+      if (n == std::string::npos) {
+        tmp = default_s;
+        n = tmp.find(pattern);
+      }
+
+      res[0] = tmp.substr(0, n);
+      res[1] = tmp.substr(n + pattern.size());
+      return res;
+    };
+    const std::string pattern{"%d"};
+    const std::vector<std::string> envs{"OPTIMIZER_RENAME_INPUT_PATTERN",
+                                        "OPTIMIZER_RENAME_OUTPUT_PATTERN"};
+    const std::vector<std::string> default_str{"input_%d", "output_%d"};
+    std::vector<std::string> result;
+    for (int i = 0; i < 2; ++i) {
+      auto env_str = fetch_env(envs[i]);
+      auto split_str = split_pattern(env_str, pattern, default_str[i]);
+      std::copy(split_str.begin(), split_str.end(),
+                std::back_insert_iterator<std::vector<std::string>>(result));
+    }
+    return result;
+  }
+
+  void rename_input_output(Graph& graph) {
+    std::unordered_set<std::string> initializer_names(
+        graph.initializer_names().begin(), graph.initializer_names().end());
+
+    const auto rename_patterns = fetchPatternFromEnv();
+
+    for (int i = 0; i < graph.inputs().size(); ++i) {
+      auto& value = graph.inputs()[i];
+      // ingore when input aslo in initializer
+      if (initializer_names.count(value->uniqueName()) > 0) {
+        continue;
+      }
+      std::string current_name =
+          rename_patterns[0] + std::to_string(i) + rename_patterns[1];
+
+      value->setUniqueName(current_name);
+    }
+
+    for (int i = 0; i < graph.outputs().size(); ++i) {
+      auto& value = graph.outputs()[i];
+      std::string current_name =
+          rename_patterns[2] + std::to_string(i) + rename_patterns[3];
+      value->setUniqueName(current_name);
+    }
+  }
+
+  std::shared_ptr<PostPassAnalysis> runPass(Graph& graph) override {
+    rename_input_output(graph);
+    return std::shared_ptr<PostPassAnalysis>(new PostPassAnalysis());
+  }
+};
+
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxoptimizer/test/optimizer_test.py
+++ b/onnxoptimizer/test/optimizer_test.py
@@ -3119,6 +3119,39 @@ class TestOptimizer(unittest.TestCase):
         assert optimized_model.graph.input[0].name == "input_0"
         assert optimized_model.graph.output[0].name == "output_0"
 
+    def test_rename_input_output_with_env_variable(self):  # type: () -> None
+        os.environ["OPTIMIZER_RENAME_INPUT_PATTERN"] = "INPUT__%d_"
+        os.environ["OPTIMIZER_RENAME_OUTPUT_PATTERN"] = "OUTPUT__%d_"
+
+        X = helper.make_tensor_value_info('X', TensorProto.FLOAT, [3, 2])
+        X1 = helper.make_tensor_value_info('X1', TensorProto.FLOAT, [3, 2])
+        Y = helper.make_tensor_value_info('Y', TensorProto.FLOAT, [3, 2])
+
+        node_def = helper.make_node(
+            'Add',
+            ['X', 'X1'],
+            ['X2'],
+        )
+
+        node_def2 = helper.make_node(
+            'Identity',
+            ['X2'],
+            ['Y'],
+        )
+
+        graph = helper.make_graph(
+            [node_def, node_def2],        # nodes
+            'test',      # name
+            [X, X1],  # inputs
+            [Y],  # outputs
+        )
+        optimized_model = self._optimized(
+            graph, ["rename_input_output"], False)
+
+        assert optimized_model.graph.input[0].name == "INPUT__0_"
+        assert optimized_model.graph.input[1].name == "INPUT__1_"
+        assert optimized_model.graph.output[0].name == "OUTPUT__0_"
+
     def test_fuse_reduction_unsqueeze(self):  # type: () -> None
         # type: (Tuple[int, ...], List[int], List[int], bool) -> Tuple[int, ...]
         def _calculate_post_transform_shape(input_shape, reduction_axes, unsqueeze_axes, keepdim):

--- a/onnxoptimizer/test/optimizer_test.py
+++ b/onnxoptimizer/test/optimizer_test.py
@@ -3114,7 +3114,7 @@ class TestOptimizer(unittest.TestCase):
             [shape],   # initialzer
         )
         optimized_model = self._optimized(
-            graph, ["rename_input_output"], False)
+            graph, ["rename_input_output"], compare_result=False)
 
         assert optimized_model.graph.input[0].name == "input_0"
         assert optimized_model.graph.output[0].name == "output_0"
@@ -3146,7 +3146,7 @@ class TestOptimizer(unittest.TestCase):
             [Y],  # outputs
         )
         optimized_model = self._optimized(
-            graph, ["rename_input_output"], False)
+            graph, ["rename_input_output"], compare_result=False)
 
         assert optimized_model.graph.input[0].name == "INPUT__0_"
         assert optimized_model.graph.input[1].name == "INPUT__1_"


### PR DESCRIPTION
User can set input/output name pattern with environment variable `OPTIMIZER_RENAME_INPUT_PATTERN `(default: `input_%d`)and  `OPTIMIZER_RENAME_OUTPUT_PATTERN` (default: `output_%d`)
1. ths pattern is `xxx%dxxx`, 'xxx' is  any string including empty string. 
2. `%d` will be replaced by number in order, start from 0
