### PR TITLE
model_util: Use ofstream offset type

### DIFF
--- a/onnxoptimizer/model_util.cc
+++ b/onnxoptimizer/model_util.cc
@@ -24,7 +24,7 @@ namespace optimization {
 namespace {
 struct ExternalDataInfo {
   std::string location;
-  int64_t offset = {-1};
+  std::ofstream::off_type offset = {-1};
   int64_t length = {-1};
 
   ExternalDataInfo(const std::string& location) : location(location) {}


### PR DESCRIPTION
libc++ use long long instead of long for the offset causing ambiguity.

```
onnxoptimizer/model_util.cc:193:35: error: use of overloaded operator '-' is ambiguous (with operand types 'pos_type' (aka 'fpos<__mbstate_t>') and 'int64_t' (aka 'long'))
  info.length = data_file.tellp() - info.offset;
                ~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~
```