### PR TITLE
fix eliminate_nop_split assert failed

### DIFF
--- a/onnxoptimizer/passes/eliminate_nop_split.h
+++ b/onnxoptimizer/passes/eliminate_nop_split.h
@@ -29,7 +29,7 @@ struct EliminateNopSplit final : public PredicateBasedPass {
 
   bool runTransform(Node* node, Graph& graph,
                     NodeDestroyType& destroy_current) override {
-    auto* input = node->input();
+    auto* input = node->inputs()[0];
     const auto& sizes = input->sizes();
     int64_t axis = GetValueFromAttrWithDefault(node, kaxis, int64_t{0});
     axis = AddYIfNegative(axis, static_cast<int64_t>(sizes.size()));


### PR DESCRIPTION
Afer Split-11， `split` is an input instead of an attribute.  Getting first input of node  with code `node->input()`  will assert fail, `node->inputs()[0]` will solve it.