### PR TITLE
Fix Assertion Const Node Tensor Request when Node has value_int Rather than Value

### DIFF
--- a/onnxoptimizer/passes/extract_constant_to_initializer.h
+++ b/onnxoptimizer/passes/extract_constant_to_initializer.h
@@ -30,7 +30,7 @@ struct ExtractConstantToInitializer final : public PredicateBasedPass {
   }
 
   bool patternMatchPredicate(Node* node) override {
-    return node->kind() == kConstant;
+    return node->kind() == kConstant && node->hasAttribute(kvalue);
   }
 
   bool runTransform(Node* node, Graph& graph,

--- a/onnxoptimizer/passes/pass_util.h
+++ b/onnxoptimizer/passes/pass_util.h
@@ -138,7 +138,7 @@ bool IsConstantTensor(const Node* n, const W& which_input,
 inline const Tensor* FetchConstantTensor(const Value* v) {
   const uint32_t kind = v->node()->kind();
   auto* graph = v->owningGraph();
-  if (kind == kConstant) {
+  if (kind == kConstant && v->node()->hasAttribute(kvalue)) {
     return &v->node()->t(kvalue);
   } else if (graph->is_constant_initializer(v)) {
     return &*graph->getInitializer(v->uniqueName());


### PR DESCRIPTION
This PR adds a check to extract_constant_to_initializer and the FetchConstantTensor function (in pass_util.h) that ensures the constant node actually contains a Tensor (rather than a value_int or some other type). If not checked, this causes an assertion failure when these pass and function are used. 

See Issue: https://github.com/onnx/optimizer/issues/173

