### PR TITLE
Bug fix  pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ requires-python = ">= 3.10"
 [project.urls]
 Homepage = 'https://github.com/onnx/optimizer'
 
-[console_scripts]
 [project.scripts]
 onnxoptimizer = "onnxoptimizer:main"
 


### PR DESCRIPTION
[project.scripts] has to be used in pyproject.toml

Without that, the tool cannot be used as cli tool