### PR TITLE
Add fuse_consecutive_squeeze_unsqueeze pass

### DIFF
--- a/onnxoptimizer/pass_registry.h
+++ b/onnxoptimizer/pass_registry.h
@@ -44,6 +44,7 @@
 #include "onnxoptimizer/passes/fuse_consecutive_concats.h"
 #include "onnxoptimizer/passes/fuse_consecutive_log_softmax.h"
 #include "onnxoptimizer/passes/fuse_consecutive_reduce_unsqueeze.h"
+#include "onnxoptimizer/passes/fuse_consecutive_squeeze_unsqueeze.h"
 #include "onnxoptimizer/passes/fuse_consecutive_squeezes.h"
 #include "onnxoptimizer/passes/fuse_consecutive_transposes.h"
 #include "onnxoptimizer/passes/fuse_matmul_add_bias_into_gemm.h"
@@ -98,6 +99,7 @@ struct GlobalPassRegistry {
     registerPass<FuseConsecutiveLogSoftmax>();
     registerPass<FuseConsecutiveReduceUnsqueeze>();
     registerPass<FuseConsecutiveSqueezes>();
+    registerPass<FuseConsecutiveSqueezeUnsqueeze>();
     registerPass<FuseConsecutiveTransposes>();
     registerPass<FuseMatMulAddBiasIntoGemm>();
     registerPass<FusePadIntoConv>();

--- a/onnxoptimizer/passes/fuse_consecutive_squeeze_unsqueeze.h
+++ b/onnxoptimizer/passes/fuse_consecutive_squeeze_unsqueeze.h
@@ -1,0 +1,114 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+#pragma once
+
+// Eliminate a Squeeze immediately followed by an inverse Unsqueeze (or an
+// Unsqueeze immediately followed by an inverse Squeeze) when the two operators
+// cancel each other out.
+//
+// Squeeze then Unsqueeze:
+//   X has shape [2, 1, 3, 1]
+//   Y = Squeeze(X, axes=[1, 3])   -> shape [2, 3]
+//   Z = Unsqueeze(Y, axes=[1, 3]) -> shape [2, 1, 3, 1]
+// After:
+//   Z = X
+//
+// Unsqueeze then Squeeze:
+//   X has shape [2, 3]
+//   Y = Unsqueeze(X, axes=[1, 3]) -> shape [2, 1, 3, 1]
+//   Z = Squeeze(Y, axes=[1, 3])   -> shape [2, 3]
+// After:
+//   Z = X
+#include <algorithm>
+
+#include "onnxoptimizer/pass.h"
+#include "onnxoptimizer/passes/logging.h"
+#include "onnxoptimizer/passes/pass_util.h"
+
+namespace ONNX_NAMESPACE {
+namespace optimization {
+
+struct FuseConsecutiveSqueezeUnsqueeze final : public PredicateBasedPass {
+  explicit FuseConsecutiveSqueezeUnsqueeze()
+      : PredicateBasedPass(PassType::Nop, PassEfficiency::Complete,
+                           PassOptimizationType::Compute) {}
+
+  std::string getPassName() const override {
+    return "fuse_consecutive_squeeze_unsqueeze";
+  }
+
+  bool patternMatchPredicate(Node *node) override {
+    return CheckKind(node, kUnsqueeze, 0, kSqueeze) ||
+           CheckKind(node, kSqueeze, 0, kUnsqueeze);
+  }
+
+  // Normalize (possibly negative) axes to non-negative indices with respect to
+  // `rank`, then sort. Returns false when `rank` is unknown (< 0) but a
+  // negative axis is present, since we cannot resolve it safely.
+  static bool NormalizeAxes(std::vector<int64_t> &axes, int64_t rank) {
+    for (auto &axis : axes) {
+      if (axis < 0) {
+        if (rank < 0) {
+          return false;
+        }
+        axis += rank;
+      }
+    }
+    std::sort(axes.begin(), axes.end());
+    return true;
+  }
+
+  // For a canceling Squeeze/Unsqueeze pair both axes lists are indexed against
+  // the same "outer" rank: the Squeeze's input rank, which equals the
+  // Unsqueeze's output rank. Recover it from whichever value carries shape
+  // info; returns -1 when it is unknown.
+  static int64_t ReferenceRank(const Node *squeeze, const Node *unsqueeze) {
+    if (squeeze->input(0)->has_sizes()) {
+      return static_cast<int64_t>(squeeze->input(0)->sizes().size());
+    }
+    if (unsqueeze->output()->has_sizes()) {
+      return static_cast<int64_t>(unsqueeze->output()->sizes().size());
+    }
+    return -1;
+  }
+
+  bool runTransform(Node *node, Graph &graph,
+                    NodeDestroyType &destroy_current) override {
+    destroy_current = NodeDestroyType::DestroyZero;
+    Node *prev = PrevNode(node, 0);
+
+    std::vector<int64_t> axes, prev_axes;
+    if (!GetValueFromAttrOrInput(node, kaxes, 1, axes) ||
+        !GetValueFromAttrOrInput(prev, kaxes, 1, prev_axes)) {
+      return false;
+    }
+
+    const Node *squeeze = node->kind() == kSqueeze ? node : prev;
+    const Node *unsqueeze = node->kind() == kUnsqueeze ? node : prev;
+    const int64_t rank = ReferenceRank(squeeze, unsqueeze);
+    if (!NormalizeAxes(axes, rank) || !NormalizeAxes(prev_axes, rank)) {
+      return false;
+    }
+
+    // The pair cancels out only when both operators touch exactly the same set
+    // of axes. Since Squeeze/Unsqueeze only remove/insert size-1 dimensions,
+    // matching axes make the two nodes a no-op.
+    if (axes != prev_axes) {
+      return false;
+    }
+
+    if (!tryReplacingAllUsesWith(node->output(), prev->input(0))) {
+      return false;
+    }
+    destroy_current = NodeDestroyType::DestroyOne;
+    return true;
+  }
+};
+
+}  // namespace optimization
+}  // namespace ONNX_NAMESPACE

--- a/onnxoptimizer/test/optimizer_test.py
+++ b/onnxoptimizer/test/optimizer_test.py
@@ -2884,6 +2884,108 @@ class TestOptimizer(unittest.TestCase):
         optimized_model = self._optimized(graph, ["fuse_consecutive_squeezes"])
         assert len(optimized_model.graph.node) == 3
 
+    def test_fuse_consecutive_squeeze_unsqueeze(self):  # type: () -> None
+        # Squeeze followed by an inverse Unsqueeze cancels out, leaving only the
+        # trailing consumer (Relu) fed directly by the input.
+        nodes = [
+            helper.make_node("Squeeze", ["X", "axes"], ["Y"]),
+            helper.make_node("Unsqueeze", ["Y", "axes"], ["Z"]),
+            helper.make_node("Relu", ["Z"], ["W"]),
+        ]
+        initializers = [
+            helper.make_tensor(
+                "axes", TensorProto.INT64, (2,),
+                np.array([1, 3], dtype=np.int64).tobytes(), raw=True,
+            )
+        ]
+        graph = helper.make_graph(
+            nodes,
+            "test",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, (2, 1, 3, 1))],
+            [helper.make_tensor_value_info("W", TensorProto.FLOAT, (2, 1, 3, 1))],
+            initializer=initializers,
+        )
+        optimized_model = self._optimized(
+            graph, ["fuse_consecutive_squeeze_unsqueeze", "eliminate_deadend"]
+        )
+        assert len(optimized_model.graph.node) == 1
+        assert optimized_model.graph.node[0].op_type == "Relu"
+        assert optimized_model.graph.node[0].input[0] == "X"
+
+    def test_fuse_consecutive_unsqueeze_squeeze(self):  # type: () -> None
+        # Unsqueeze followed by an inverse Squeeze cancels out.
+        nodes = [
+            helper.make_node("Unsqueeze", ["X", "axes"], ["Y"]),
+            helper.make_node("Squeeze", ["Y", "axes"], ["Z"]),
+            helper.make_node("Relu", ["Z"], ["W"]),
+        ]
+        initializers = [
+            helper.make_tensor(
+                "axes", TensorProto.INT64, (2,),
+                np.array([1, 3], dtype=np.int64).tobytes(), raw=True,
+            )
+        ]
+        graph = helper.make_graph(
+            nodes,
+            "test",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, (2, 3))],
+            [helper.make_tensor_value_info("W", TensorProto.FLOAT, (2, 3))],
+            initializer=initializers,
+        )
+        optimized_model = self._optimized(
+            graph, ["fuse_consecutive_squeeze_unsqueeze", "eliminate_deadend"]
+        )
+        assert len(optimized_model.graph.node) == 1
+        assert optimized_model.graph.node[0].op_type == "Relu"
+        assert optimized_model.graph.node[0].input[0] == "X"
+
+    def test_fuse_consecutive_squeeze_unsqueeze_no_fuse(self):  # type: () -> None
+        # Different axes must NOT be eliminated.
+        nodes = [
+            helper.make_node("Squeeze", ["X", "sq_axes"], ["Y"]),
+            helper.make_node("Unsqueeze", ["Y", "un_axes"], ["Z"]),
+        ]
+        initializers = [
+            helper.make_tensor(
+                "sq_axes", TensorProto.INT64, (1,),
+                np.array([1], dtype=np.int64).tobytes(), raw=True,
+            ),
+            helper.make_tensor(
+                "un_axes", TensorProto.INT64, (1,),
+                np.array([0], dtype=np.int64).tobytes(), raw=True,
+            ),
+        ]
+        graph = helper.make_graph(
+            nodes,
+            "test",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, (2, 1, 3))],
+            [helper.make_tensor_value_info("Z", TensorProto.FLOAT, (1, 2, 3))],
+            initializer=initializers,
+        )
+        optimized_model = self._optimized(
+            graph, ["fuse_consecutive_squeeze_unsqueeze", "eliminate_deadend"]
+        )
+        assert len(optimized_model.graph.node) == 2
+
+    def test_fuse_consecutive_squeeze_unsqueeze_negative_axes(self):  # type: () -> None
+        # Negative axes that resolve to the same positions still cancel out.
+        graph = parser.parse_graph("""
+           agraph (float[2, 1, 3, 1] X) => (float[2, 1, 3, 1] W)
+           {
+              Axes = Constant<value=int64[2]{1, -1}> ()
+              Y = Squeeze (X, Axes)
+              Z = Unsqueeze (Y, Axes)
+              W = Relu (Z)
+           }
+        """)
+        optimized_model = self._optimized(
+            graph, ["fuse_consecutive_squeeze_unsqueeze", "eliminate_deadend"]
+        )
+        assert all(
+            n.op_type not in ("Squeeze", "Unsqueeze")
+            for n in optimized_model.graph.node
+        )
+
     @pytest.mark.xfail
     def test_fuse_consecutive_softmax_log_axis(self):  # type: () -> None
         for axis in range(3):


### PR DESCRIPTION
PyTorch-to-ONNX export frequently emits a Squeeze immediately followed by an inverse Unsqueeze (or the reverse). When both operators touch exactly the same set of axes they cancel each other out, but no existing pass removed the pair -- fuse_consecutive_squeezes/fuse_consecutive_unsqueezes only handle same-op chains.

This adds a Nop pass that eliminates a Squeeze/Unsqueeze pair when their axes match, rewiring the pair's consumers to the original input. Axes are read from either the attribute (opset <= 12) or the input tensor (opset
>= 13), and negative axes are normalized against the shared outer rank,
recovered from whichever value carries shape information.

Fixes onnxsim/onnxsim#315


Claude-Session: https://claude.ai/code/session_01Qp39CpZJVZ2wkXuy5Ghwyw