### PR TITLE
Fix fuse_pad_into_pool folding zero-padding into MaxPool

### DIFF
--- a/onnxoptimizer/passes/fuse_pad_into_pool.h
+++ b/onnxoptimizer/passes/fuse_pad_into_pool.h
@@ -13,9 +13,15 @@
 // After:
 //   Z = pool(X, Y) with "pads" attribute set
 //
-// the pass handles the case when Pad is zero-padding the input
-// (i.e. mode=constant and constant_value=0)
+// The pass only fires when Pad uses mode=constant and the constant value
+// matches the value the pool implicitly uses for its own padding:
+//   - AveragePool (with count_include_pad=1): constant_value = 0
+//   - MaxPool:                                constant_value = -inf
+// MaxPool ignores its padded elements, which is equivalent to padding with
+// -inf. Folding a zero-padding Pad into a MaxPool is therefore incorrect
+// (see https://github.com/onnxsim/onnxsim/issues/290).
 
+#include <limits>
 #include <numeric>
 
 #include "onnx/defs/tensor_util.h"
@@ -67,6 +73,17 @@ struct FusePadIntoPool final : public PredicateBasedPass {
     }
 
     // Process 'Constant_value'
+    //
+    // The Pad can only be fused when it fills the padded region with the same
+    // value the pool implicitly uses for its own padding:
+    //   - AveragePool (with count_include_pad=1): 0
+    //   - MaxPool: -inf (MaxPool ignores padded elements, which is equivalent
+    //     to padding with -inf). Folding a zero-padding Pad into a MaxPool
+    //     would change the result whenever a window's real values are all
+    //     negative -- see https://github.com/onnxsim/onnxsim/issues/290.
+    const bool is_maxpool = pool->kind() == Symbol("MaxPool");
+    const double required_pad_value =
+        is_maxpool ? -std::numeric_limits<double>::infinity() : double(0);
     {
       union ConstantValueType {
         int32_t i32;
@@ -79,32 +96,35 @@ struct FusePadIntoPool final : public PredicateBasedPass {
         int16_t i16;
       } cv;
 
-#define Define_GetConstantValueFromInput(token) \
-  (GetValueFromInput(pad, 2, cv.token) && cv.token == decltype(cv.token)(0))
+#define Match_ConstantValueFromInput(token) \
+  (GetValueFromInput(pad, 2, cv.token) &&   \
+   static_cast<double>(cv.token) == required_pad_value)
 
-      do {
-        if (GetValueFromAttr(pad, kvalue, cv.f64) && cv.f64 == double(0)) {
-          break;
-        }
-        if (pad->inputs().size() >= 3) {
-          if (pad->input(2)->uniqueName().empty()) {
-            break;
-          }
-          if (Define_GetConstantValueFromInput(i32) ||
-              Define_GetConstantValueFromInput(i64) ||
-              Define_GetConstantValueFromInput(f32) ||
-              Define_GetConstantValueFromInput(f64) ||
-              Define_GetConstantValueFromInput(ui8) ||
-              Define_GetConstantValueFromInput(i8) ||
-              Define_GetConstantValueFromInput(ui16) ||
-              Define_GetConstantValueFromInput(i16)) {
-            break;
-          }
-          return false;
-        }
-      } while (0);
+      bool pad_value_matches;
+      if (GetValueFromAttr(pad, kvalue, cv.f64)) {
+        // Explicit 'value' attribute (opset 10 and below).
+        pad_value_matches = (cv.f64 == required_pad_value);
+      } else if (pad->inputs().size() >= 3 &&
+                 !pad->input(2)->uniqueName().empty()) {
+        // Explicit 'constant_value' input (opset 11 and above).
+        pad_value_matches = Match_ConstantValueFromInput(i32) ||
+                            Match_ConstantValueFromInput(i64) ||
+                            Match_ConstantValueFromInput(f32) ||
+                            Match_ConstantValueFromInput(f64) ||
+                            Match_ConstantValueFromInput(ui8) ||
+                            Match_ConstantValueFromInput(i8) ||
+                            Match_ConstantValueFromInput(ui16) ||
+                            Match_ConstantValueFromInput(i16);
+      } else {
+        // No constant value specified: Pad defaults to 0.
+        pad_value_matches = (required_pad_value == double(0));
+      }
 
-#undef Define_GetConstantValueFromInput
+#undef Match_ConstantValueFromInput
+
+      if (!pad_value_matches) {
+        return false;
+      }
     }
 
     // check if some values in 'pads' prevents us from fusing it into 'Conv'

--- a/onnxoptimizer/test/optimizer_test.py
+++ b/onnxoptimizer/test/optimizer_test.py
@@ -2081,8 +2081,38 @@ class TestOptimizer(unittest.TestCase):
         assert list(optimized_model.graph.node[0].attribute[2].ints) == [0, 0, 1, 1]
 
     def test_fuse_pad_into_maxpool_no_optional_value_opset10(self):
+        # A Pad with the default constant value (0) must NOT be folded into a
+        # MaxPool: MaxPool pads with -inf, so zero-padding changes the result.
+        # See https://github.com/onnxsim/onnxsim/issues/290
         pad = helper.make_node(
             "Pad", ["X"], ["P"], mode="constant", pads=[0, 0, 0, 0, 0, 0, 1, 1]
+        )
+        max_pool = helper.make_node("MaxPool", ["P"], ["Z"], kernel_shape=[3, 3])
+        graph = helper.make_graph(
+            [pad, max_pool],
+            "test",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, (1, 5, 2, 2))],
+            [helper.make_tensor_value_info("Z", TensorProto.FLOAT, (1, 5, 1, 1))],
+        )
+        optimized_model = self._optimized(
+            graph,
+            ["fuse_pad_into_pool"],
+            False,
+            opset_imports=[helper.make_opsetid("", 10)],
+        )
+
+        assert optimized_model.graph == graph
+
+    def test_fuse_pad_into_maxpool_neg_inf_value_opset10(self):
+        # A Pad with constant value -inf is the correct fill value for MaxPool
+        # and can be folded into it.
+        pad = helper.make_node(
+            "Pad",
+            ["X"],
+            ["P"],
+            mode="constant",
+            pads=[0, 0, 0, 0, 0, 0, 1, 1],
+            value=float("-inf"),
         )
         max_pool = helper.make_node("MaxPool", ["P"], ["Z"], kernel_shape=[3, 3])
         graph = helper.make_graph(
@@ -2133,6 +2163,9 @@ class TestOptimizer(unittest.TestCase):
         assert list(optimized_model.graph.node[0].attribute[2].ints) == [0, 0, 1, 1]
 
     def test_fuse_pad_into_maxpool_no_optional_value(self):
+        # No constant_value input => Pad defaults to 0, which must NOT be folded
+        # into MaxPool (MaxPool pads with -inf).
+        # See https://github.com/onnxsim/onnxsim/issues/290
         pad = helper.make_node("Pad", ["X", "Pads"], ["P"], mode="constant")
         max_pool = helper.make_node("MaxPool", ["P"], ["Z"], kernel_shape=[3, 3])
         graph = helper.make_graph(
@@ -2154,10 +2187,7 @@ class TestOptimizer(unittest.TestCase):
         )
         optimized_model = self._optimized(graph, ["fuse_pad_into_pool"])
 
-        assert len(list(optimized_model.graph.node)) == 1
-        assert optimized_model.graph.node[0].op_type == "MaxPool"
-        assert optimized_model.graph.node[0].attribute[1].name == "pads"
-        assert list(optimized_model.graph.node[0].attribute[1].ints) == [0, 0, 1, 1]
+        assert optimized_model.graph == graph
 
     def test_fuse_pad_into_avgpool_with_optional_value(self):
         pad = helper.make_node("Pad", ["X", "Pads", "Constant_value"], ["P"], mode="constant")
@@ -2196,7 +2226,10 @@ class TestOptimizer(unittest.TestCase):
         assert optimized_model.graph.node[0].attribute[2].name == "pads"
         assert list(optimized_model.graph.node[0].attribute[2].ints) == [0, 0, 1, 1]
 
-    def test_fuse_pad_into_maxpool_with_optional_value(self):
+    def test_fuse_pad_into_maxpool_with_zero_optional_value(self):
+        # This is the exact case reported in
+        # https://github.com/onnxsim/onnxsim/issues/290 : a Pad with an explicit
+        # constant value of 0 must NOT be folded into a MaxPool.
         pad = helper.make_node("Pad", ["X", "Pads", "Constant_value"], ["P"], mode="constant")
         max_pool = helper.make_node("MaxPool", ["P"], ["Z"], kernel_shape=[3, 3])
         graph = helper.make_graph(
@@ -2219,6 +2252,39 @@ class TestOptimizer(unittest.TestCase):
                     TensorProto.FLOAT,
                     dims=(),
                     vals=np.array([0]).astype(np.float32).tobytes(),
+                    raw=True,
+                ),
+            ],
+        )
+        optimized_model = self._optimized(graph, ["fuse_pad_into_pool"])
+
+        assert optimized_model.graph == graph
+
+    def test_fuse_pad_into_maxpool_with_neg_inf_optional_value(self):
+        # A Pad with constant value -inf is the correct fill value for MaxPool
+        # and can be folded into it.
+        pad = helper.make_node("Pad", ["X", "Pads", "Constant_value"], ["P"], mode="constant")
+        max_pool = helper.make_node("MaxPool", ["P"], ["Z"], kernel_shape=[3, 3])
+        graph = helper.make_graph(
+            [pad, max_pool],
+            "test",
+            [
+                helper.make_tensor_value_info("X", TensorProto.FLOAT, (1, 5, 2, 2)),
+            ],
+            [helper.make_tensor_value_info("Z", TensorProto.FLOAT, (1, 5, 1, 1))],
+            [
+                helper.make_tensor(
+                    "Pads",
+                    TensorProto.INT64,
+                    dims=(8,),
+                    vals=np.array([0, 0, 0, 0, 0, 0, 1, 1]).astype(np.int64).tobytes(),
+                    raw=True,
+                ),
+                helper.make_tensor(
+                    "Constant_value",
+                    TensorProto.FLOAT,
+                    dims=(),
+                    vals=np.array([float("-inf")]).astype(np.float32).tobytes(),
                     raw=True,
                 ),
             ],
@@ -2317,7 +2383,29 @@ class TestOptimizer(unittest.TestCase):
         assert list(optimized_model.graph.node[0].attribute[2].ints) == [1, 1]
 
     def test_fuse_pad_into_maxpool_1d_opset10(self):
+        # Default constant value (0) => must NOT fold into MaxPool.
         pad = helper.make_node("Pad", ["X"], ["P"], mode="constant", pads=[0, 0, 1, 0, 0, 1])
+        max_pool = helper.make_node("MaxPool", ["P"], ["Z"], kernel_shape=[3])
+        graph = helper.make_graph(
+            [pad, max_pool],
+            "test",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, (1, 5, 1))],
+            [helper.make_tensor_value_info("Z", TensorProto.FLOAT, (1, 5, 1))],
+        )
+        optimized_model = self._optimized(
+            graph,
+            ["fuse_pad_into_pool"],
+            False,
+            opset_imports=[helper.make_opsetid("", 10)],
+        )
+
+        assert optimized_model.graph == graph
+
+    def test_fuse_pad_into_maxpool_1d_neg_inf_opset10(self):
+        pad = helper.make_node(
+            "Pad", ["X"], ["P"], mode="constant", pads=[0, 0, 1, 0, 0, 1],
+            value=float("-inf"),
+        )
         max_pool = helper.make_node("MaxPool", ["P"], ["Z"], kernel_shape=[3])
         graph = helper.make_graph(
             [pad, max_pool],
@@ -2367,6 +2455,7 @@ class TestOptimizer(unittest.TestCase):
         assert list(optimized_model.graph.node[0].attribute[2].ints) == [1, 1]
 
     def test_fuse_pad_into_maxpool_1d(self):
+        # No constant_value input => Pad defaults to 0 => must NOT fold.
         pad = helper.make_node("Pad", ["X", "Pads"], ["P"], mode="constant")
         max_pool = helper.make_node("MaxPool", ["P"], ["Z"], kernel_shape=[3])
         graph = helper.make_graph(
@@ -2384,6 +2473,39 @@ class TestOptimizer(unittest.TestCase):
                     vals=np.array([0, 0, 1, 0, 0, 1]).astype(np.int64).tobytes(),
                     raw=True,
                 )
+            ],
+        )
+        optimized_model = self._optimized(graph, ["fuse_pad_into_pool"])
+
+        assert optimized_model.graph == graph
+
+    def test_fuse_pad_into_maxpool_1d_neg_inf(self):
+        pad = helper.make_node(
+            "Pad", ["X", "Pads", "Constant_value"], ["P"], mode="constant"
+        )
+        max_pool = helper.make_node("MaxPool", ["P"], ["Z"], kernel_shape=[3])
+        graph = helper.make_graph(
+            [pad, max_pool],
+            "test",
+            [
+                helper.make_tensor_value_info("X", TensorProto.FLOAT, (1, 5, 1)),
+            ],
+            [helper.make_tensor_value_info("Z", TensorProto.FLOAT, (1, 5, 1))],
+            [
+                helper.make_tensor(
+                    "Pads",
+                    TensorProto.INT64,
+                    dims=(6,),
+                    vals=np.array([0, 0, 1, 0, 0, 1]).astype(np.int64).tobytes(),
+                    raw=True,
+                ),
+                helper.make_tensor(
+                    "Constant_value",
+                    TensorProto.FLOAT,
+                    dims=(),
+                    vals=np.array([float("-inf")]).astype(np.float32).tobytes(),
+                    raw=True,
+                ),
             ],
         )
         optimized_model = self._optimized(graph, ["fuse_pad_into_pool"])
@@ -2424,8 +2546,32 @@ class TestOptimizer(unittest.TestCase):
         assert list(optimized_model.graph.node[0].attribute[2].ints) == [1, 1, 1, 1]
 
     def test_fuse_pad_into_maxpool_existing_maxpool_pad_opset10(self):
+        # Default constant value (0) => must NOT fold into MaxPool.
         pad = helper.make_node(
             "Pad", ["X"], ["P"], mode="constant", pads=[0, 0, 0, 0, 0, 0, 1, 1]
+        )
+        max_pool = helper.make_node(
+            "MaxPool", ["P"], ["Z"], kernel_shape=[3, 3], pads=[1, 1, 0, 0]
+        )
+        graph = helper.make_graph(
+            [pad, max_pool],
+            "test",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, (1, 5, 1, 1))],
+            [helper.make_tensor_value_info("Z", TensorProto.FLOAT, (1, 5, 1, 1))],
+        )
+        optimized_model = self._optimized(
+            graph,
+            ["fuse_pad_into_pool"],
+            False,
+            opset_imports=[helper.make_opsetid("", 10)],
+        )
+
+        assert optimized_model.graph == graph
+
+    def test_fuse_pad_into_maxpool_existing_maxpool_pad_neg_inf_opset10(self):
+        pad = helper.make_node(
+            "Pad", ["X"], ["P"], mode="constant", pads=[0, 0, 0, 0, 0, 0, 1, 1],
+            value=float("-inf"),
         )
         max_pool = helper.make_node(
             "MaxPool", ["P"], ["Z"], kernel_shape=[3, 3], pads=[1, 1, 0, 0]
@@ -2483,6 +2629,7 @@ class TestOptimizer(unittest.TestCase):
         assert list(optimized_model.graph.node[0].attribute[2].ints) == [1, 1, 1, 1]
 
     def test_fuse_pad_into_maxpool_existing_maxpool_pad(self):
+        # No constant_value input => Pad defaults to 0 => must NOT fold.
         pad = helper.make_node("Pad", ["X", "Pads"], ["P"], mode="constant")
         max_pool = helper.make_node(
             "MaxPool", ["P"], ["Z"], kernel_shape=[3, 3], pads=[1, 1, 0, 0]
@@ -2502,6 +2649,41 @@ class TestOptimizer(unittest.TestCase):
                     vals=np.array([0, 0, 0, 0, 0, 0, 1, 1]).astype(np.int64).tobytes(),
                     raw=True,
                 )
+            ],
+        )
+        optimized_model = self._optimized(graph, ["fuse_pad_into_pool"])
+
+        assert optimized_model.graph == graph
+
+    def test_fuse_pad_into_maxpool_existing_maxpool_pad_neg_inf(self):
+        pad = helper.make_node(
+            "Pad", ["X", "Pads", "Constant_value"], ["P"], mode="constant"
+        )
+        max_pool = helper.make_node(
+            "MaxPool", ["P"], ["Z"], kernel_shape=[3, 3], pads=[1, 1, 0, 0]
+        )
+        graph = helper.make_graph(
+            [pad, max_pool],
+            "test",
+            [
+                helper.make_tensor_value_info("X", TensorProto.FLOAT, (1, 5, 1, 1)),
+            ],
+            [helper.make_tensor_value_info("Z", TensorProto.FLOAT, (1, 5, 1, 1))],
+            [
+                helper.make_tensor(
+                    "Pads",
+                    TensorProto.INT64,
+                    dims=(8,),
+                    vals=np.array([0, 0, 0, 0, 0, 0, 1, 1]).astype(np.int64).tobytes(),
+                    raw=True,
+                ),
+                helper.make_tensor(
+                    "Constant_value",
+                    TensorProto.FLOAT,
+                    dims=(),
+                    vals=np.array([float("-inf")]).astype(np.float32).tobytes(),
+                    raw=True,
+                ),
             ],
         )
         optimized_model = self._optimized(graph, ["fuse_pad_into_pool"])


### PR DESCRIPTION
MaxPool ignores its padded elements, which is equivalent to padding with -inf. The pass previously folded a Pad with constant_value=0 (or an unspecified value, which defaults to 0) into MaxPool by moving the padding into the pool's `pads` attribute. This changes the result whenever a pooling window's real values are all negative: Pad(0)+MaxPool yields 0 while the fused MaxPool yields the (negative) window maximum.

Make the required Pad constant value depend on the pool type:
  - AveragePool (with count_include_pad=1): 0
  - MaxPool:                                -inf

Also restructure the constant-value check so an unspecified Pad value correctly blocks fusion into MaxPool instead of being treated as a match.

Update the MaxPool tests that encoded the old behavior to assert no fusion for value=0/default, and add companion tests confirming Pad(value=-inf) folds correctly.

Fixes onnxsim/onnxsim#290


Claude-Session: https://claude.ai/code/session_013sB8xKJyd86p47c2vfXMVD