### PR TITLE
Fix eliminate_shape_gather abort on out-of-range Gather index

### DIFF
--- a/onnxoptimizer/passes/eliminate_shape_gather.h
+++ b/onnxoptimizer/passes/eliminate_shape_gather.h
@@ -45,7 +45,16 @@ struct EliminateShapeGather final : public PredicateBasedPass {
     indices_val = AddYIfNegative(indices_val, end - start);
     indices_val += start;
 
-    ONNX_ASSERT(indices_val < dims.size());
+    // The Gather index may not resolve to a valid axis of the shaped tensor:
+    // an index beyond the rank, or a negative result after the adjustment
+    // above. Skipping the rewrite (rather than asserting) lets simplification
+    // continue on dynamic-shape graphs instead of aborting the process. Note
+    // dims.size() is unsigned, so a negative indices_val must be rejected
+    // before the comparison to avoid it promoting to a large unsigned value.
+    if (indices_val < 0 ||
+        indices_val >= static_cast<int64_t>(dims.size())) {
+      return false;
+    }
 
     if (!dims[indices_val].is_int || dims[indices_val].dim == -1) {
       return false;

--- a/onnxoptimizer/test/optimizer_test.py
+++ b/onnxoptimizer/test/optimizer_test.py
@@ -4038,6 +4038,40 @@ class TestOptimizer(unittest.TestCase):
 
         assert len(optimized_model.graph.node) == 3
 
+    def _shape_gather_graph(self, index):  # type: (int) -> GraphProto
+        X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [3, 2])
+        Y = helper.make_tensor_value_info("Y", TensorProto.INT64, [1])
+        X2 = helper.make_tensor_value_info("X2", TensorProto.FLOAT, [3, 2])
+        indices = helper.make_tensor(
+            "indices", TensorProto.INT64, [1], np.array([index], dtype=np.int64)
+        )
+        nodes = [
+            helper.make_node("Relu", ["X"], ["X2"]),
+            helper.make_node("Shape", ["X2"], ["X3"]),
+            helper.make_node("Gather", ["X3", "indices"], ["X4"]),
+            helper.make_node("Identity", ["X4"], ["Y"]),
+        ]
+        return helper.make_graph(
+            nodes, "test", [X], [Y], [indices], value_info=[X2]
+        )
+
+    def test_eliminate_shape_gather_index_out_of_range(self):  # type: () -> None
+        # A Gather index >= the rank of the shaped tensor must not abort the
+        # pass (this used to fail an ONNX_ASSERT and crash the process). The
+        # index cannot be statically resolved to an axis, so the pass should
+        # decline to rewrite and leave all four nodes untouched.
+        graph = self._shape_gather_graph(5)
+        optimized_model = self._optimized(graph, ["eliminate_shape_gather"], False)
+        assert len(optimized_model.graph.node) == 4
+
+    def test_eliminate_shape_gather_negative_index_out_of_range(self):  # type: () -> None
+        # A negative index that stays negative after normalization (here -5 on
+        # a rank-2 shape) likewise must not crash. dims.size() is unsigned, so
+        # the guard has to reject the negative value before the comparison.
+        graph = self._shape_gather_graph(-5)
+        optimized_model = self._optimized(graph, ["eliminate_shape_gather"], False)
+        assert len(optimized_model.graph.node) == 4
+
     def test_eliminate_nop_reshape(self):  # type: () -> None
         X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [3, 4, 5])
         Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [3, 4, 5])

--- a/onnxoptimizer/test/optimizer_test.py
+++ b/onnxoptimizer/test/optimizer_test.py
@@ -4061,7 +4061,12 @@ class TestOptimizer(unittest.TestCase):
         # index cannot be statically resolved to an axis, so the pass should
         # decline to rewrite and leave all four nodes untouched.
         graph = self._shape_gather_graph(5)
-        optimized_model = self._optimized(graph, ["eliminate_shape_gather"], False)
+        # compare_result=False: the model keeps a deliberately out-of-bounds
+        # Gather index, so it cannot be executed by onnxruntime for output
+        # comparison. We only assert the pass declines to rewrite.
+        optimized_model = self._optimized(
+            graph, ["eliminate_shape_gather"], compare_result=False
+        )
         assert len(optimized_model.graph.node) == 4
 
     def test_eliminate_shape_gather_negative_index_out_of_range(self):  # type: () -> None
@@ -4069,7 +4074,11 @@ class TestOptimizer(unittest.TestCase):
         # a rank-2 shape) likewise must not crash. dims.size() is unsigned, so
         # the guard has to reject the negative value before the comparison.
         graph = self._shape_gather_graph(-5)
-        optimized_model = self._optimized(graph, ["eliminate_shape_gather"], False)
+        # compare_result=False for the same reason as above: an out-of-bounds
+        # index makes the graph non-executable under onnxruntime.
+        optimized_model = self._optimized(
+            graph, ["eliminate_shape_gather"], compare_result=False
+        )
         assert len(optimized_model.graph.node) == 4
 
     def test_eliminate_nop_reshape(self):  # type: () -> None


### PR DESCRIPTION
runTransform asserted indices_val < dims.size(), which aborts the process when the resolved Gather index is not a valid axis of the shaped tensor -- either an index beyond the tensor's rank, or a value that stays negative after the start/negative-index normalization. Because dims.size() is unsigned, a negative indices_val also promoted to a large unsigned value and tripped the assertion.

Replace the assertion with a bounds guard that rejects negative and out-of-range indices (skipping the rewrite) so the pass leaves such nodes untouched instead of crashing. This surfaced on dynamic-shape detection models (e.g. FasterRCNN-10) after data-propagating shape inference populates dims.

Add regression tests for both the positive-out-of-range and negative-index cases. Full optimizer test suite passes (157 passed, 5 skipped, 6 xfailed).


Claude-Session: https://claude.ai/code/session_016qp5y8hZ8ktgPuAYKJtZZG