### PR TITLE
Add CI to run pytest under AddressSanitizer

### DIFF
--- a/.github/workflows/pytest-asan.yml
+++ b/.github/workflows/pytest-asan.yml
@@ -45,12 +45,9 @@ jobs:
 
       - name: Install test dependencies
         # onnxruntime is intentionally omitted: it is only used by the tests for
-        # optional numerical comparison (guarded by `has_ort`), and its
-        # uninstrumented C++ throws exceptions that trip ASan's __cxa_throw
-        # interceptor (CHECK failed: real___cxa_throw != 0) when the runtime is
-        # preloaded, aborting the interpreter before any real issue is found.
-        # Skipping it keeps ASan focused on onnxoptimizer's own C++ while still
-        # running every optimize() call and model check.
+        # optional numerical comparison (guarded by `has_ort`), so skipping it
+        # keeps ASan focused on onnxoptimizer's own C++ while still running every
+        # optimize() call and model check.
         run: python -m pip install pytest pytest-xdist numpy
 
       - name: Run pytest under AddressSanitizer
@@ -63,6 +60,15 @@ jobs:
           # errors (heap-buffer-overflow, use-after-free, ...) in onnxoptimizer.
           ASAN_OPTIONS: "detect_leaks=0:halt_on_error=1:symbolize=1"
         run: |
-          export LD_PRELOAD="$(gcc -print-file-name=libasan.so)"
+          # libasan must come first in the preload list (ASan requirement), but
+          # libstdc++ must be preloaded alongside it: the `onnx` Python wheel is
+          # an uninstrumented C++ extension that throws C++ exceptions (e.g. from
+          # checker.check_model / shape_inference, which the tests exercise
+          # constantly). Without libstdc++ loaded at ASan init, the __cxa_throw
+          # interceptor can't resolve the real symbol and aborts the process with
+          # "CHECK failed: ... real___cxa_throw != 0" on the first raised
+          # exception. Preloading libstdc++ lets the interceptor find __cxa_throw
+          # so exceptions unwind normally and only genuine memory errors fail CI.
+          export LD_PRELOAD="$(gcc -print-file-name=libasan.so):$(gcc -print-file-name=libstdc++.so.6)"
           # Limit worker count to keep ASan's larger memory footprint in check.
           python -m pytest onnxoptimizer/test/ -n 2 -v

--- a/.github/workflows/pytest-asan.yml
+++ b/.github/workflows/pytest-asan.yml
@@ -40,7 +40,7 @@ jobs:
           # DT_NEEDED of the shared objects.
           ASAN_FLAGS: "-fsanitize=address -fno-omit-frame-pointer -g"
         run: |
-          export CMAKE_ARGS="-DCMAKE_CXX_FLAGS='${ASAN_FLAGS}' -DCMAKE_C_FLAGS='${ASAN_FLAGS}' -DCMAKE_EXE_LINKER_FLAGS=-fsanitize=address -DCMAKE_SHARED_LINKER_FLAGS=-fsanitize=address -DCMAKE_MODULE_LINKER_FLAGS=-fsanitize=address"
+          export CXXFLAGS=-fsanitize=address LDFLAGS=-fsanitize=address
           python -m pip install --no-build-isolation -v .
 
       - name: Install test dependencies

--- a/.github/workflows/pytest-asan.yml
+++ b/.github/workflows/pytest-asan.yml
@@ -1,0 +1,68 @@
+# Copyright (c) ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Pytest with AddressSanitizer
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pytest-asan:
+    name: Pytest (ASan)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Install build dependencies
+        run: python -m pip install --upgrade pip protobuf setuptools wheel "cmake>=3.22"
+
+      - name: Build and install onnxoptimizer with AddressSanitizer
+        env:
+          # Build the native extension (and the bundled onnx / protobuf) with
+          # ASan. The flags are single-quoted so setup.py's shlex.split keeps
+          # each multi-token value as one -D... argument. -g / frame pointers
+          # give readable stack traces; the linker flags make libasan a
+          # DT_NEEDED of the shared objects.
+          ASAN_FLAGS: "-fsanitize=address -fno-omit-frame-pointer -g"
+        run: |
+          export CMAKE_ARGS="-DCMAKE_CXX_FLAGS='${ASAN_FLAGS}' -DCMAKE_C_FLAGS='${ASAN_FLAGS}' -DCMAKE_EXE_LINKER_FLAGS=-fsanitize=address -DCMAKE_SHARED_LINKER_FLAGS=-fsanitize=address -DCMAKE_MODULE_LINKER_FLAGS=-fsanitize=address"
+          python -m pip install --no-build-isolation -v .
+
+      - name: Install test dependencies
+        # onnxruntime is intentionally omitted: it is only used by the tests for
+        # optional numerical comparison (guarded by `has_ort`), and its
+        # uninstrumented C++ throws exceptions that trip ASan's __cxa_throw
+        # interceptor (CHECK failed: real___cxa_throw != 0) when the runtime is
+        # preloaded, aborting the interpreter before any real issue is found.
+        # Skipping it keeps ASan focused on onnxoptimizer's own C++ while still
+        # running every optimize() call and model check.
+        run: python -m pip install pytest pytest-xdist numpy
+
+      - name: Run pytest under AddressSanitizer
+        env:
+          # CPython itself is not built with ASan, so the runtime has to be
+          # preloaded; otherwise dlopen of the instrumented extension fails
+          # with "ASan runtime does not come first in initial library list".
+          # detect_leaks=0 suppresses leaks from the uninstrumented interpreter
+          # and third-party libraries so the job only fails on genuine memory
+          # errors (heap-buffer-overflow, use-after-free, ...) in onnxoptimizer.
+          ASAN_OPTIONS: "detect_leaks=0:halt_on_error=1:symbolize=1"
+        run: |
+          export LD_PRELOAD="$(gcc -print-file-name=libasan.so)"
+          # Limit worker count to keep ASan's larger memory footprint in check.
+          python -m pytest onnxoptimizer/test/ -n 2 -v

--- a/.github/workflows/pytest-asan.yml
+++ b/.github/workflows/pytest-asan.yml
@@ -42,6 +42,14 @@ jobs:
         run: |
           export CXXFLAGS=-fsanitize=address LDFLAGS=-fsanitize=address
           python -m pip install --no-build-isolation -v .
+          # The test step runs `pytest onnxoptimizer/test/` from the repo root, so
+          # `import onnxoptimizer` binds to the in-tree source package instead of the
+          # installed one -- and the source tree has no compiled extension. Build it
+          # in place as well (reusing the cmake build pip just produced) so the
+          # onnx_opt_cpp2py_export module sits next to that source; without this the
+          # tests fail at collection with "ModuleNotFoundError: No module named
+          # 'onnxoptimizer.onnx_opt_cpp2py_export'".
+          python setup.py build_ext --inplace
 
       - name: Install test dependencies
         # onnxruntime is intentionally omitted: it is only used by the tests for


### PR DESCRIPTION
Build the native extension (and the bundled onnx/protobuf) with -fsanitize=address and run the existing pytest suite with the ASan runtime preloaded, so memory errors (heap-buffer-overflow, use-after-free, ...) in onnxoptimizer's C++ passes are caught in CI.

CPython is not built with ASan, so libasan is LD_PRELOADed and detect_leaks=0 suppresses leaks from the uninstrumented interpreter and third-party libraries. onnxruntime is omitted from the test dependencies because its uninstrumented C++ throws exceptions that trip ASan's __cxa_throw interceptor; it is only used for optional numerical comparison, so every optimize() call is still exercised.


Claude-Session: https://claude.ai/code/session_01GewbTty3fkFT4G9u6J1JJn